### PR TITLE
Moves random support from rand to getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ flexi_logger = { version = "0.24", default_features = false }
 getrandom = "0.2.8"
 log = "0.4"
 percent-encoding = "2.2"
-# rand = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 ureq = { version = "2.5", features = ["json"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,26 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 flexi_logger = { version = "0.24", default_features = false }
+getrandom = "0.2.8"
 log = "0.4"
 percent-encoding = "2.2"
-rand = "0.8"
+# rand = "0.8"
 serde = { version = "1.0", features = [ "derive" ] }
 ureq = { version = "2.5", features = ["json"] }
+
+# The following support getrandom
+[patch.crates-io.atty]
+git = "https://github.com/xobs/atty.git"
+branch = "add-xous-support"
+
+[patch.crates-io.os_str_bytes]
+git = "https://github.com/xobs/os_str_bytes.git"
+branch = "add-xous-support"
+
+[patch.crates-io.ring]
+git = "https://github.com/betrusted-io/ring-xous.git"
+rev = "09207048c393d524a34f63cf65c85a973012a21d" # use the commitref because we're still updating the branch
+
+[patch.crates-io.getrandom]
+git = "https://github.com/xobs/getrandom.git"
+branch = "xous-support-do-not-merge"

--- a/src/mtxcli/interactive.rs
+++ b/src/mtxcli/interactive.rs
@@ -49,6 +49,8 @@ impl<'a> Interactive<'a> {
         }
         let mut quit = false;
         let stdin = io::stdin();
+        self.mtxcli.prompt();
+        println!("Welcome to {}. Type /help for available commands", self.mtxcli.app);
         for line in stdin.lock().lines() {
             let mut cmdline = line?;
             let maybe_verb = tokenize(&mut cmdline);

--- a/src/mtxcli/web.rs
+++ b/src/mtxcli/web.rs
@@ -1,4 +1,4 @@
-use rand;
+// use rand;
 use serde::{Serialize,Deserialize};
 use ureq::serde_json::{Value, Map};
 use ureq;
@@ -399,7 +399,9 @@ pub fn client_sync(server: &str, filter: &str, since: &str, timeout: i32,
 }
 
 pub fn gen_txn_id() -> String {
-    let txn_id: u32 = rand::random();
+    // let txn_id: u32 = rand::random();
+    let mut txn_id: u32 = 0;
+    getrandom::getrandom(&txn_id);
     txn_id.to_string()
 }
 

--- a/src/mtxcli/web.rs
+++ b/src/mtxcli/web.rs
@@ -1,4 +1,3 @@
-// use rand;
 use serde::{Serialize,Deserialize};
 use ureq::serde_json::{Value, Map};
 use ureq;
@@ -399,9 +398,9 @@ pub fn client_sync(server: &str, filter: &str, since: &str, timeout: i32,
 }
 
 pub fn gen_txn_id() -> String {
-    // let txn_id: u32 = rand::random();
-    let mut txn_id: u32 = 0;
-    getrandom::getrandom(&txn_id);
+    let mut bytes = [0u8; 4];
+    getrandom::getrandom(&mut bytes).expect("couldn't get random data");
+    let txn_id = u32::from_le_bytes(bytes);
     txn_id.to_string()
 }
 


### PR DESCRIPTION
This is a work in progress.

Currently compile results in:
```
tmarble@espoir 123 :) cargo build --target riscv32imac-unknown-xous-elf
    Updating git repository `https://github.com/xobs/atty.git`
    Updating git repository `https://github.com/xobs/getrandom.git`
    Updating git repository `https://github.com/xobs/os_str_bytes.git`
    Updating git repository `https://github.com/betrusted-io/ring-xous.git`
    Updating crates.io index
error: failed to select a version for `num-traits`.
    ... required by package `xous-api-names v0.9.14`
    ... which satisfies dependency `xous-names = "^0.9.14"` of package `getrandom v0.2.8 (https://github.com/xobs/getrandom.git?branch=xous-support-do-not-merge#dc28e32b)`
    ... which satisfies dependency `getrandom = "^0.2.8"` (locked to 0.2.8) of package `mtxcli v0.5.0 (/home/tmarble/src/github/betrusted-io/mtxcli)`
versions that meet the requirements `^0.2.14` are: 0.2.15, 0.2.14

all possible versions conflict with previously selected packages.

  previously selected package `num-traits v0.2.11`
    ... which satisfies dependency `num-traits = "^0.2"` (locked to 0.2.11) of package `chrono v0.4.22`
    ... which satisfies dependency `chrono = "^0.4.22"` (locked to 0.4.22) of package `flexi_logger v0.24.0`
    ... which satisfies dependency `flexi_logger = "^0.24"` (locked to 0.24.0) of package `mtxcli v0.5.0 (/home/tmarble/src/github/betrusted-io/mtxcli)`

failed to select a version for `num-traits` which could resolve this conflict
tmarble@espoir 124 :( 
```